### PR TITLE
Fix optimizer state loading from checkpoint

### DIFF
--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -121,7 +121,7 @@ class Trainer(object):
             print("=> loaded checkpoint '{}' (epoch {})"
                   .format(self.args.resume, checkpoint['epoch']))
             self.args.start_epoch = checkpoint['epoch']
-            self.optimizer.load_state_dict = checkpoint['optimizer']
+            self.optimizer.load_state_dict(checkpoint['optimizer'])
 
     def training(self, epoch):
         self.model.train()


### PR DESCRIPTION
The code is missing parentheses for method invocation. Currently, it assigns the checkpoint dictionary to the ```load_state_dict``` method itself rather than calling the method with the checkpoint data as argument.